### PR TITLE
Add Red Hat OpenShift deployment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ cvs-rendered.yaml
 *.crt
 *.key
 *.pem
+
+# Helm generated files
+infra/blueprint/bringup/charts/
+infra/blueprint/custom_video_bucket_meta.json

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Recommended for production deployments requiring scalability, high availability,
 #### Deployment Guides
 
 - **[AWS EKS Deployment](docs/docs/aws-eks-deployment.md)** - Deploy on Amazon Elastic Kubernetes Service
+- **[Red Hat OpenShift AI Deployment](docs/docs/openshift-deployment.md)** - Deploy on Red Hat OpenShift AI (RHOAI)
 
 ## Using CDS
 

--- a/docs/docs/openshift-deployment.md
+++ b/docs/docs/openshift-deployment.md
@@ -1,0 +1,743 @@
+# Deploying Cosmos Dataset Search on Red Hat OpenShift AI
+
+## What We're Deploying
+
+The Cosmos Dataset Search (CDS) Blueprint ingests video datasets, generates embeddings
+using an NVIDIA NIM embedding model, and makes them searchable via natural-language queries
+through a React web UI.
+
+| Component | Image | GPU | Purpose |
+|-----------|-------|-----|---------|
+| **cosmos-embed** (NIM Operator) | `nvcr.io/nim/nvidia/cosmos-embed1:1.0.0` | 1 | Video/image embedding via NIMService |
+| **visual-search** | `nvcr.io/nvidia/blueprint/cosmos-dataset-search:1.0.0` | 0 | Search API service |
+| **visual-search-react-ui** | NVCF subchart | 0 | React web UI |
+| **nginx-proxy** | `nginxinc/nginx-unprivileged:1.25.3-alpine` | 0 | Reverse proxy (Route entry point) |
+| **milvus** | NVCF subchart (9 pods) | 1 (indexNode) | Vector database (GPU-accelerated indexing) |
+| **minio** | NVCF subchart | 0 | S3-compatible object storage |
+| **etcd** | NVCF subchart | 0 | Milvus metadata store |
+| **kafka + zookeeper** | NVCF subchart | 0 | Milvus message queue |
+
+**Data flow:**
+
+- **Ingest:** videos (S3) → visual-search → cosmos-embed (embeddings) → Milvus
+- **Search:** user query → visual-search → cosmos-embed (query embedding) → Milvus (vector search) → results
+
+**Total:** 2 GPUs minimum (cosmos-embed + milvus indexNode).
+
+### NIM Operator Components
+
+When deployed with the NIM Operator (recommended on OpenShift), the cosmos-embed NIM
+is managed as a pair of custom resources instead of a standalone Deployment:
+
+- **NIMCache** — downloads and caches the model on a PVC. Annotated with
+  `helm.sh/resource-policy: keep` to survive upgrades and uninstalls.
+- **NIMService** — runs the inference server, references its NIMCache for model storage,
+  manages replicas, GPU allocation, and health probes.
+
+## Tested Hardware
+
+| Parameter | Value |
+|-----------|-------|
+| Platform | Red Hat OpenShift 4.14+ |
+| GPU nodes | 1+ nodes with NVIDIA L40S / A100 40GB / H100 |
+| GPUs per node | 1+ |
+| Total GPUs | 2 (cosmos-embed + milvus indexNode) |
+| VRAM | 16 GB+ per GPU (24 GB+ recommended) |
+| CPU | 8+ cores |
+| RAM | 32 GB+ |
+| Storage | 50 GiB dynamically provisioned PVC (cosmos-embed model cache) + 10 GiB disk for cache/decode buffers |
+| API keys | [NGC API key](https://org.ngc.nvidia.com/setup/api-keys) |
+
+Minimum for reproduction: 2 x NVIDIA L40S / A100 / H100 GPUs (16 GB+ VRAM each), 50 GiB storage.
+
+## What's Different from Upstream
+
+| Area | Upstream Default | OpenShift Deployment | Impact |
+|------|------------------|----------------------|--------|
+| Pod management | Subchart Deployments | NIM Operator (NIMCache + NIMService) | Automated model download, cache lifecycle |
+| External access | `kubectl port-forward` | OpenShift Route with TLS + nginx proxy | Production-grade ingress |
+| Volume provisioning | `emptyDir` (ephemeral) | Dynamic PVCs via NIM Operator | Model cache persists across restarts |
+| Security context | Pods run as specific UIDs (e.g. 1000) | Custom SCC + RoleBinding | Compatible with OpenShift SCC |
+| Secrets | Manual creation | Helm-managed via `openshift.secrets` | Single `helm install` creates all secrets |
+| Object storage | External AWS S3 | Built-in MinIO (AWS S3 optional) | No external dependency by default |
+
+## Deployment Files
+
+All OpenShift customizations are codified in the `infra/blueprint/bringup/` directory alongside the upstream chart:
+
+- **`values-openshift.yaml`** — Helm values overlay for OpenShift. Contains all OpenShift-specific overrides (NIM Operator, security contexts, tolerations, secrets, storage).
+- **`visual-search/templates/openshift.yaml`** — Helm template gated by `openshift.enabled`. Creates custom SCC, RoleBinding, Route, nginx proxy, and secrets.
+- **`visual-search/templates/nim-cosmos-embed.yaml`** — NIMCache + NIMService template for cosmos-embed, gated by the NIM Operator CRD (`apps.nvidia.com/v1alpha1`).
+- **`visual-search/values.yaml`** — Base chart values with `openshift.enabled: false` and `nimOperator.cosmosEmbed.enabled: false` defaults.
+
+## Prerequisites
+
+### CLI Tools
+
+- `oc` (OpenShift CLI) logged into your cluster
+- `helm` v3.12+
+- `aws` CLI (for data ingestion with MinIO/S3)
+- `python3` and `make` (for CDS CLI and dataset preparation)
+
+### Cluster Requirements
+
+- Red Hat OpenShift 4.14+
+- NVIDIA GPU Operator installed and configured
+- NIM Operator installed (provides `apps.nvidia.com/v1alpha1` API).
+  See [NIM Operator installation guide](https://docs.nvidia.com/nim-operator/latest/install.html)
+- At least 1 GPU node available
+
+### Verify GPU Availability
+
+```bash
+oc get nodes -l nvidia.com/gpu.present=true
+oc describe node <gpu-node> | grep -A 5 "Allocatable"
+```
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `NGC_API_KEY` | Yes | — | NGC API key for image pulls and model downloads |
+
+### OpenShift Block (`openshift:`)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `openshift.enabled` | `false` | Master toggle for all OpenShift resources |
+| `openshift.route.enabled` | `false` | Create an OpenShift Route for the UI |
+| `openshift.scc.create` | `false` | Create custom SCC + RoleBinding |
+| `openshift.secrets.create` | `false` | Create NGC and encryption secrets from values |
+| `openshift.nginx.enabled` | `false` | Deploy nginx reverse proxy for path-based routing |
+| `openshift.minio.route.enabled` | `false` | Create a Route for MinIO (data ingestion) |
+
+### NIM Operator Block (`nimOperator:`)
+
+The cosmos-embed NIM has the following configuration:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `nimOperator.cosmosEmbed.enabled` | `false` | Deploy cosmos-embed via NIM Operator |
+| `nimOperator.cosmosEmbed.replicas` | `1` | Number of inference replicas |
+| `nimOperator.cosmosEmbed.service.name` | `cosmos-embed-nim` | Kubernetes service name (used for DNS) |
+| `nimOperator.cosmosEmbed.image.repository` | `nvcr.io/nim/nvidia/cosmos-embed1` | NGC container image |
+| `nimOperator.cosmosEmbed.image.tag` | `1.0.0` | Image version |
+| `nimOperator.cosmosEmbed.resources.limits.nvidia.com/gpu` | `1` | GPU allocation |
+| `nimOperator.cosmosEmbed.storage.pvc.size` | `50Gi` | Model cache PVC size |
+| `nimOperator.cosmosEmbed.storage.pvc.storageClass` | `""` | StorageClass (uses cluster default if empty) |
+| `nimOperator.cosmosEmbed.secrets.pullSecret` | `ngc-secret` | Image pull secret name |
+| `nimOperator.cosmosEmbed.secrets.authSecret` | `ngc-api` | NGC API secret name |
+| `nimOperator.cosmosEmbed.expose.service.port` | `8000` | Service port |
+| `nimOperator.cosmosEmbed.tolerations` | `[]` | Node tolerations for GPU taints |
+| `nimOperator.cosmosEmbed.startupProbe` | (see values) | Startup probe configuration |
+
+## Deployment
+
+### 1. Create Namespace
+
+```bash
+oc new-project cosmos-cds
+```
+
+### 2. Create Secrets
+
+The chart can create secrets automatically via `openshift.secrets.create: true` —
+just pass the NGC API key via `--set` at install time.
+Alternatively, create all secrets manually before install (recommended for production).
+
+> **Helm auto-creation:** If using auto-creation, skip this step and pass keys via
+> `--set` flags in step 3. If you pre-create secrets here, you **must** disable the
+> chart's secret creation to prevent it from overwriting your secrets with empty
+> defaults. In `values-openshift.yaml`, set:
+> ```yaml
+> visual-search:
+>   openshift:
+>     secrets:
+>       create: false
+> ```
+> Also omit the `--set` flags in step 3.
+
+```bash
+export NGC_API_KEY="<your-ngc-api-key>"
+export CUSTOM_NAMESPACE=cosmos-cds
+export RELEASE_NAME=cosmos-cds
+
+# Image pull secret — ngc-secret (for pulling NIM containers from nvcr.io)
+oc create secret docker-registry ngc-secret \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password="${NGC_API_KEY}" \
+  -n $CUSTOM_NAMESPACE
+
+oc label secret ngc-secret \
+  app.kubernetes.io/managed-by=Helm -n $CUSTOM_NAMESPACE
+oc annotate secret ngc-secret \
+  meta.helm.sh/release-name=$RELEASE_NAME \
+  meta.helm.sh/release-namespace=$CUSTOM_NAMESPACE -n $CUSTOM_NAMESPACE
+
+# Image pull secret — nvcr-io (used by subchart image pulls)
+oc create secret docker-registry nvcr-io \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password="${NGC_API_KEY}" \
+  -n $CUSTOM_NAMESPACE
+
+oc label secret nvcr-io \
+  app.kubernetes.io/managed-by=Helm -n $CUSTOM_NAMESPACE
+oc annotate secret nvcr-io \
+  meta.helm.sh/release-name=$RELEASE_NAME \
+  meta.helm.sh/release-namespace=$CUSTOM_NAMESPACE -n $CUSTOM_NAMESPACE
+
+# NGC API secret (for NIM Operator model downloads)
+oc create secret generic ngc-api \
+  --from-literal=NGC_API_KEY="${NGC_API_KEY}" \
+  -n $CUSTOM_NAMESPACE
+
+oc label secret ngc-api \
+  app.kubernetes.io/managed-by=Helm -n $CUSTOM_NAMESPACE
+oc annotate secret ngc-api \
+  meta.helm.sh/release-name=$RELEASE_NAME \
+  meta.helm.sh/release-namespace=$CUSTOM_NAMESPACE -n $CUSTOM_NAMESPACE
+
+# Encryption key secret (used by the visual-search API)
+export SECRETS_ENCRYPTION_KEY=$(python3 infra/blueprint/bringup/generate_secret_key.py | grep "export" | cut -d"'" -f2)
+oc create secret generic secret-encryption-key \
+  --from-literal=SECRETS_ENCRYPTION_KEY="$SECRETS_ENCRYPTION_KEY" \
+  -n $CUSTOM_NAMESPACE
+
+oc label secret secret-encryption-key \
+  app.kubernetes.io/managed-by=Helm -n $CUSTOM_NAMESPACE
+oc annotate secret secret-encryption-key \
+  meta.helm.sh/release-name=$RELEASE_NAME \
+  meta.helm.sh/release-namespace=$CUSTOM_NAMESPACE -n $CUSTOM_NAMESPACE
+```
+
+Link the pull secret to the NIM Operator service account:
+
+```bash
+oc create sa nim-cache-sa -n $CUSTOM_NAMESPACE || true
+oc secrets link nim-cache-sa ngc-secret --for=pull -n $CUSTOM_NAMESPACE
+```
+
+### 3. Install the Chart
+
+```bash
+helm dependency build infra/blueprint/bringup
+
+helm upgrade --install $RELEASE_NAME infra/blueprint/bringup \
+  -n $CUSTOM_NAMESPACE \
+  -f infra/blueprint/bringup/values-openshift.yaml \
+  --set "visual-search.openshift.secrets.ngcApiKey=$NGC_API_KEY" \
+  --timeout 45m
+```
+
+> If you pre-created secrets in step 2, omit the `--set` flags above.
+
+This creates:
+- 1 x NIMCache (triggers cosmos-embed model download)
+- 1 x NIMService (runs inference after cache is ready)
+- 1 x OpenShift Route with TLS (external UI access via nginx proxy)
+- 1 x Custom SCC + RoleBinding (allows subchart pods to run as image UIDs)
+- All required secrets (NGC registry, NGC API key, encryption key)
+- Visual Search API, React UI, nginx proxy
+- Milvus vector database with MinIO, etcd, Kafka, ZooKeeper
+- Subchart cosmos-embed Deployment is disabled (`cosmos-embed.enabled: false`)
+
+### 4. Monitor Model Downloads
+
+NIMCache resources download models from NGC. This can take 10-20 minutes depending
+on model size and network speed.
+
+```bash
+oc get nimcache -n $CUSTOM_NAMESPACE -w
+```
+
+Wait until the cache shows `Ready`:
+
+```
+NAME                      STATUS   AGE
+cosmos-embed-nim-cache    Ready    15m
+```
+
+## Verification
+
+### Check NIMService Status
+
+```bash
+oc get nimservice -n $CUSTOM_NAMESPACE
+```
+
+### Check Pods
+
+```bash
+oc get pods -n $CUSTOM_NAMESPACE
+```
+
+All pods should reach `Running 1/1`.
+
+**Expected pods** (pod names are prefixed with your release name):
+
+| Pod | Purpose | Managed By |
+|-----|---------|------------|
+| `cosmos-embed-nim` | Video embedding NIM (GPU) | NIM Operator |
+| `visual-search` | Search API service | Helm |
+| `visual-search-react-ui` | Web UI | Helm |
+| `nginx-proxy` | Reverse proxy (Route entry point) | Helm |
+| `<release>-milvus-*` | Vector database (9 pods) | Helm |
+| `<release>-minio` | S3-compatible object storage | Helm |
+| `<release>-etcd` | Milvus metadata store | Helm |
+| `<release>-kafka` | Milvus message queue | Helm |
+| `<release>-zookeeper` | Kafka coordination | Helm |
+
+### Health Endpoints
+
+```bash
+echo -n "cosmos-embed: "
+oc exec -n $CUSTOM_NAMESPACE deployment/cosmos-embed-nim -- \
+  curl -s http://localhost:8000/v1/health/ready
+echo
+```
+
+## Accessing the UI
+
+The Helm chart creates an OpenShift Route with TLS edge termination. Get the URL:
+
+```bash
+export CUSTOM_API_ENDPOINT=$(oc get route visual-search -n $CUSTOM_NAMESPACE -o jsonpath='{.spec.host}')
+echo "https://$CUSTOM_API_ENDPOINT/cosmos-dataset-search"
+```
+
+Open `https://<route-host>/cosmos-dataset-search` in a browser.
+
+## Install CDS CLI
+
+> **Note**: `CUSTOM_API_ENDPOINT` must be exported (set in Verification step) before running this script.
+
+```bash
+cd infra/blueprint/bringup
+bash client_up.sh
+```
+
+**Duration**: 2-3 minutes
+
+**What happens**:
+- Installs CDS CLI from packaged source
+- Creates Python virtual environment at the project root (`.venv/`)
+- Configures CLI with the OpenShift Route endpoint
+- Validates deployment by listing pipelines
+
+**Verify CLI works**:
+
+```bash
+cd /path/to/cosmos-dataset-search
+source .venv/bin/activate
+cds pipelines list
+cds collections list
+```
+
+## Data Ingestion
+
+### Setup: Source Environment Variables
+
+CDS works with any S3-compatible storage. Configure the `CUSTOM_*` variables for your storage provider:
+
+**Option A: Built-in MinIO** (deployed with the chart):
+
+```bash
+cd /path/to/cosmos-dataset-search
+source .venv/bin/activate
+
+MINIO_ROUTE=$(oc get route minio -n $CUSTOM_NAMESPACE -o jsonpath='{.spec.host}')
+
+export CUSTOM_AWS_ACCESS_KEY_ID=minioadmin
+export CUSTOM_AWS_SECRET_ACCESS_KEY=minioadmin
+export CUSTOM_AWS_REGION=us-east-1
+export CUSTOM_S3_BUCKET_NAME=cosmos-videos
+export CUSTOM_S3_FOLDER=msrvtt-videos
+export CUSTOM_ENDPOINT_URL="https://$MINIO_ROUTE"
+export CUSTOM_API_ENDPOINT=$(oc get route visual-search -n $CUSTOM_NAMESPACE -o jsonpath='{.spec.host}')
+```
+
+**Option B: AWS S3** (or any external S3):
+
+```bash
+cd /path/to/cosmos-dataset-search
+source .venv/bin/activate
+
+export CUSTOM_AWS_ACCESS_KEY_ID=<your-access-key>
+export CUSTOM_AWS_SECRET_ACCESS_KEY=<your-secret-key>
+export CUSTOM_AWS_REGION=<your-region>
+export CUSTOM_S3_BUCKET_NAME=<your-bucket>
+export CUSTOM_S3_FOLDER=<your-folder>
+# CUSTOM_ENDPOINT_URL is not needed for AWS S3
+export CUSTOM_API_ENDPOINT=$(oc get route visual-search -n $CUSTOM_NAMESPACE -o jsonpath='{.spec.host}')
+```
+
+> **Note**: Set `CUSTOM_ENDPOINT_URL` only for non-AWS S3 storage (MinIO, ODF/Noobaa, etc.). AWS S3 uses region-based endpoints automatically.
+
+### Step 1: Prepare Dataset
+
+Download and prepare the MSR-VTT dataset. The sample config downloads 100 videos.
+
+```bash
+uv pip install datasets
+make prepare-dataset CONFIG=scripts/msrvtt_test_100.yaml
+```
+
+**Duration**: 5-10 minutes
+
+**What happens**:
+- Downloads MSRVTT_Videos.zip from HuggingFace
+- Extracts and copies 100 videos to `~/datasets/msrvtt/videos/`
+
+> **Note**: The `prepare-dataset` script only supports HuggingFace datasets that provide videos as a downloadable ZIP file. For datasets without ZIPs, you'll need to download videos separately or provide them locally.
+
+### Step 2: Upload Videos to S3
+
+```bash
+export PROFILE_NAME="${CUSTOM_S3_BUCKET_NAME}-profile"
+
+aws configure set aws_access_key_id "${CUSTOM_AWS_ACCESS_KEY_ID}" --profile "${PROFILE_NAME}"
+aws configure set aws_secret_access_key "${CUSTOM_AWS_SECRET_ACCESS_KEY}" --profile "${PROFILE_NAME}"
+aws configure set region "${CUSTOM_AWS_REGION}" --profile "${PROFILE_NAME}"
+# Set endpoint URL for MinIO (skip this line for AWS S3)
+aws configure set endpoint_url "${CUSTOM_ENDPOINT_URL}" --profile "${PROFILE_NAME}"
+
+# Check if bucket exists; create it if not
+aws s3 ls s3://$CUSTOM_S3_BUCKET_NAME --profile $PROFILE_NAME || \
+  aws --profile $PROFILE_NAME s3 mb s3://$CUSTOM_S3_BUCKET_NAME
+
+# Upload all videos from local dataset directory to MinIO bucket
+aws --profile $PROFILE_NAME s3 cp ~/datasets/msrvtt/videos/ \
+  s3://$CUSTOM_S3_BUCKET_NAME/$CUSTOM_S3_FOLDER/ --recursive
+
+# Verify upload
+echo "Videos uploaded. Checking count:"
+aws --profile $PROFILE_NAME s3 ls s3://$CUSTOM_S3_BUCKET_NAME/$CUSTOM_S3_FOLDER/ | wc -l
+```
+
+**Duration**: 1-2 minutes
+
+### Step 3: Ingest Videos
+
+The `ingest_custom_videos.sh` script **requires CUSTOM_*** variables to be set. These variables specify which S3 bucket has the videos to ingest.
+
+```bash
+cd infra/blueprint
+bash ingest_custom_videos.sh
+```
+
+**What the script does with CUSTOM_* variables:**
+- Creates AWS profile using CUSTOM_AWS_ACCESS_KEY_ID and CUSTOM_AWS_SECRET_ACCESS_KEY
+- Gets deployment URL from CUSTOM_API_ENDPOINT (set in the setup step)
+- Creates Kubernetes secret with S3 credentials
+- Creates collection with storage configuration
+- Ingests videos from s3://CUSTOM_S3_BUCKET_NAME/CUSTOM_S3_FOLDER/
+
+**Duration**: 2-5 minutes for 5 videos (default limit)
+
+**Expected output:**
+
+```
+Processed files: 5/5 ━━━━ 100%
+Status code 200: 5/5 100%
+Processed 5 files successfully
+```
+
+### Step 4: Configure CORS (External S3 Only)
+
+If using the built-in MinIO, skip this step — no CORS needed (same-origin).
+
+If using external AWS S3, **you must configure CORS on your S3 buckets**. Without it, the web UI cannot load video assets from S3.
+
+> **Note**: Requires `CUSTOM_API_ENDPOINT` and `CUSTOM_S3_BUCKET_NAME` to be set (from the Setup step above).
+
+```bash
+cd infra/blueprint/bringup
+bash verify_and_configure_cors.sh -y
+```
+
+**What the script does:**
+- Uses `CUSTOM_API_ENDPOINT` (set in the setup step) as the allowed CORS origin
+- Checks IAM permissions for GetBucketCors and PutBucketCors
+- Applies CORS policy to all buckets relevant to your deployment
+
+**Example browser error if CORS is missing**:
+```
+Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource...
+(Reason: CORS header 'Access-Control-Allow-Origin' missing)
+```
+
+> **Security tip:** The script uses your Route URL as the allowed origin. Do **not** use `*` for production. For manual CORS configuration, see [Manually Configure CORS for S3 Videos](#manually-configure-cors-for-s3-videos).
+
+### Step 5: Verify Ingestion
+
+```bash
+cds collections list
+
+ROUTE_HOST=$(oc get route visual-search -n $CUSTOM_NAMESPACE -o jsonpath='{.spec.host}')
+echo "https://$ROUTE_HOST/cosmos-dataset-search"
+```
+
+Open the Web UI and search for videos (e.g., "a person playing basketball").
+
+### Ingest Your Own Videos
+
+1. Upload videos:
+
+```bash
+aws s3 cp /path/to/your/videos/ s3://$CUSTOM_S3_BUCKET_NAME/$CUSTOM_S3_FOLDER/ \
+  --recursive --profile $PROFILE_NAME
+```
+
+2. Update `CUSTOM_*` variables if using a different bucket or credentials, then run:
+
+```bash
+cd infra/blueprint
+bash ingest_custom_videos.sh
+```
+
+## Advanced Options
+
+### Using AWS S3 Instead of MinIO
+
+By default, the OpenShift overlay deploys a built-in MinIO pod for Milvus object storage. If you prefer to use AWS S3, override the storage settings at install time:
+
+```bash
+helm upgrade --install $RELEASE_NAME infra/blueprint/bringup \
+  -n $CUSTOM_NAMESPACE \
+  -f infra/blueprint/bringup/values-openshift.yaml \
+  --set "visual-search.openshift.secrets.ngcApiKey=$NGC_API_KEY" \
+  --set "milvus.minio.enabled=false" \
+  --set "milvus.externalS3.enabled=true" \
+  --set "milvus.externalS3.host=s3.$AWS_REGION.amazonaws.com" \
+  --set "milvus.externalS3.bucketName=$S3_BUCKET_NAME" \
+  --set "milvus.externalS3.region=$AWS_REGION" \
+  --set "milvus.externalS3.useIAM=false" \
+  --set "milvus.externalS3.accessKey=$AWS_ACCESS_KEY_ID" \
+  --set "milvus.externalS3.secretKey=$AWS_SECRET_ACCESS_KEY" \
+  --timeout 45m
+```
+
+> **Note**: Unlike EKS which uses IAM Roles for Service Accounts (IRSA) for keyless S3 access, OpenShift requires explicit AWS credentials via `accessKey` and `secretKey`.
+
+### Managing Secrets
+
+> **Important**: Storage secrets must be created in the `default` namespace due to a hardcoded namespace in the visual-search application ([k8s_secrets.py](../../src/visual_search/v1/apis/k8s_secrets.py)).
+
+```bash
+# Create
+oc create secret generic my-s3-creds -n default \
+  --from-literal=aws_access_key_id=$CUSTOM_AWS_ACCESS_KEY_ID \
+  --from-literal=aws_secret_access_key=$CUSTOM_AWS_SECRET_ACCESS_KEY \
+  --from-literal=aws_region=$CUSTOM_AWS_REGION
+
+# Use in collection
+cds collections create --pipeline cosmos_video_search_milvus \
+  --name "My Collection" \
+  --config-yaml <(echo "
+tags:
+  storage-template: 's3://$CUSTOM_S3_BUCKET_NAME/$CUSTOM_S3_FOLDER/{{filename}}'
+  storage-secrets: 'my-s3-creds'
+")
+
+# List / Delete
+oc get secrets -n default
+oc delete secret my-s3-creds -n default
+```
+
+### Manually Configure CORS for S3 Videos
+
+This section applies only when using external AWS S3. If using the built-in MinIO, CORS is not required.
+
+#### Why CORS is Required
+
+When your browser tries to load videos from S3, it makes cross-origin requests. S3 blocks these requests by default unless you explicitly configure CORS rules.
+
+**Error you'll see without CORS**:
+```
+Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource...
+(Reason: CORS header 'Access-Control-Allow-Origin' missing). Status code: 200.
+```
+
+#### Required IAM Permissions
+
+Your AWS credentials must have these permissions on the S3 bucket:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "s3:PutBucketCORS",
+    "s3:GetBucketCORS"
+  ],
+  "Resource": "arn:aws:s3:::<your-bucket-name>"
+}
+```
+
+If you see an "AccessDenied" error, contact your AWS administrator to grant these permissions.
+
+#### Configure CORS
+
+```bash
+ROUTE_HOST=$(oc get route visual-search -n $CUSTOM_NAMESPACE -o jsonpath='{.spec.host}')
+
+echo "Configuring CORS for bucket: $CUSTOM_S3_BUCKET_NAME"
+echo "Allowing origin: https://$ROUTE_HOST"
+
+aws s3api put-bucket-cors \
+  --bucket $CUSTOM_S3_BUCKET_NAME \
+  --region $CUSTOM_AWS_REGION \
+  --profile $PROFILE_NAME \
+  --cors-configuration "{
+    \"CORSRules\": [{
+      \"AllowedOrigins\": [\"https://${ROUTE_HOST}\"],
+      \"AllowedMethods\": [\"GET\", \"HEAD\"],
+      \"AllowedHeaders\": [\"*\"],
+      \"ExposeHeaders\": [\"ETag\", \"Content-Length\", \"Content-Type\"],
+      \"MaxAgeSeconds\": 3600
+    }]
+  }"
+
+# Verify
+aws s3api get-bucket-cors --bucket $CUSTOM_S3_BUCKET_NAME --region $CUSTOM_AWS_REGION --profile $PROFILE_NAME
+```
+
+**Alternative: Wildcard CORS (less secure, allows any origin)**:
+
+```bash
+aws s3api put-bucket-cors \
+  --bucket $CUSTOM_S3_BUCKET_NAME \
+  --region $CUSTOM_AWS_REGION \
+  --profile $PROFILE_NAME \
+  --cors-configuration '{
+    "CORSRules": [{
+      "AllowedOrigins": ["*"],
+      "AllowedMethods": ["GET", "HEAD"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["ETag", "Content-Length", "Content-Type"],
+      "MaxAgeSeconds": 3600
+    }]
+  }'
+```
+
+#### Test CORS Configuration
+
+After configuring CORS, test that videos load in the web UI:
+
+1. Open the web UI in your browser
+2. Perform a search
+3. Click on a video result
+4. The video should load and play without errors
+
+If you still see CORS errors, verify:
+- CORS configuration is applied: `aws s3api get-bucket-cors --bucket <bucket-name> --region <region>`
+- Your Route hostname matches the allowed origin in CORS rules
+- You've configured CORS on all buckets that store videos
+
+## OpenShift-Specific Challenges and Solutions
+
+### 1. Security Context Constraints
+
+**What:** The Milvus MinIO container runs as a specific UID by default. OpenShift's
+`restricted-v2` SCC blocks this by forcing a random UID.
+
+**Error:** `container has runAsNonRoot and image has non-numeric user`
+
+**Services affected:** milvus-minio.
+
+**Fix:** The custom SCC (`<release>-nim`) created by the Helm chart when
+`openshift.scc.create: true` sets `runAsUser: RunAsAny` and
+`seLinuxContext: RunAsAny`. A RoleBinding grants this SCC to the application
+service accounts.
+
+### 2. GPU Node Tolerations
+
+**What:** GPU nodes carry `NoSchedule` taints. Without matching tolerations, pods stay
+`Pending`.
+
+**Error:** `0/N nodes are available: N node(s) had untolerated taint`
+
+**Services affected:** cosmos-embed-nim, milvus indexNode.
+
+**Fix:** Add tolerations in `values-openshift.yaml` for each GPU service:
+
+```yaml
+visual-search:
+  nimOperator:
+    cosmosEmbed:
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+```
+
+Check your taints with `oc describe node <gpu-node> | grep Taints`.
+
+### 3. Missing Secrets
+
+**What:** The chart references secrets that don't exist by default. Pods fail with
+`secret not found`.
+
+**Error:** `secret "<name>" not found`
+
+**Services affected:** All (shared secrets).
+
+**Fix:** NGC secrets are created via `openshift.secrets.create: true` or manually
+in step 2 of the deployment instructions.
+
+### 4. NIMCache PVC Sizing
+
+**What:** NIM model cache PVCs must be large enough to hold all downloaded model
+profiles. Undersized PVCs cause download failures.
+
+**Services affected:** cosmos-embed-nim-cache.
+
+**Fix:** PVC size in `values-openshift.yaml`: cosmos-embed 50 GiB. NIMCache PVCs are
+immutable — delete the NIMCache and PVC to resize, then re-run `helm install`.
+
+### 5. Helm Secret Adoption
+
+**What:** If you create secrets with `oc create secret` before `helm install`, Helm
+refuses to adopt them during install or upgrade.
+
+**Error:** `Error: rendered manifests contain a resource that already exists`
+
+**Services affected:** All (shared secrets).
+
+**Fix:** Pre-label secrets with Helm ownership metadata before install:
+
+```bash
+oc label secret <name> app.kubernetes.io/managed-by=Helm -n $CUSTOM_NAMESPACE
+oc annotate secret <name> \
+  meta.helm.sh/release-name=$RELEASE_NAME \
+  meta.helm.sh/release-namespace=$CUSTOM_NAMESPACE -n $CUSTOM_NAMESPACE
+```
+
+## Known Limitations
+
+1. **Storage secrets must be in the `default` namespace.** The visual-search application reads S3 credentials from the `default` namespace. The chart creates a RoleBinding granting the app's service accounts access to secrets in `default`. If you deploy to a different namespace, secrets must still be created in `default`.
+
+2. **Resource sizing.** The `values-openshift.yaml` resource values match the production configuration. On smaller clusters, pods like `queryNode` (12 CPU / 96Gi) and `dataNode` (6 CPU / 24Gi) may stay Pending due to insufficient capacity. Reduce resource requests in `values-openshift.yaml` to fit your cluster.
+
+## Cleanup
+
+```bash
+# Uninstall the Helm release
+helm uninstall $RELEASE_NAME -n $CUSTOM_NAMESPACE
+
+# NIMCache PVCs persist by default (helm.sh/resource-policy: keep).
+# Delete manually if you want to reclaim storage:
+oc delete nimcache --all -n $CUSTOM_NAMESPACE
+oc delete pvc -l app.nvidia.com/nim-cache -n $CUSTOM_NAMESPACE
+
+# Delete the project — removes all namespaced resources (pods, PVCs, services, etc.)
+oc delete project $CUSTOM_NAMESPACE
+
+# Clean up resources created in the default namespace
+oc delete role ${CUSTOM_NAMESPACE}-secret-access-role -n default --ignore-not-found
+oc delete rolebinding ${CUSTOM_NAMESPACE}-secret-access-binding -n default --ignore-not-found
+oc delete secret ${CUSTOM_S3_BUCKET_NAME}-secrets-videos -n default --ignore-not-found
+```

--- a/infra/blueprint/bringup/Chart.lock
+++ b/infra/blueprint/bringup/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: visual-search
+  repository: file://visual-search
+  version: 0.0.1
+- name: visual-search-react-ui
+  repository: file://visual-search-react-ui
+  version: 0.0.1
+- name: nvidia-nim-cosmos-embed
+  repository: file://triton-cosmos-embed
+  version: 1.0.0
+- name: milvus
+  repository: https://zilliztech.github.io/milvus-helm
+  version: 4.2.58
+digest: sha256:35d9b8dcdf70db591795d3aba80e0ed4cac2a388df3c3e8474331abe797c86f4
+generated: "2026-05-11T14:05:49.860084305+03:00"

--- a/infra/blueprint/bringup/Chart.yaml
+++ b/infra/blueprint/bringup/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: cosmos-dataset-search
+description: Cosmos Dataset Search (CDS) — semantic search across video datasets on OpenShift
+type: application
+version: 0.6.0
+appVersion: 0.6.0
+
+dependencies:
+  - name: visual-search
+    version: 0.0.1
+    repository: file://visual-search
+
+  - name: visual-search-react-ui
+    version: 0.0.1
+    repository: file://visual-search-react-ui
+
+  - name: nvidia-nim-cosmos-embed
+    version: 1.0.0
+    repository: file://triton-cosmos-embed
+    alias: cosmos-embed
+    condition: cosmos-embed.enabled
+
+  - name: milvus
+    version: 4.2.58
+    repository: https://zilliztech.github.io/milvus-helm

--- a/infra/blueprint/bringup/client_up.sh
+++ b/infra/blueprint/bringup/client_up.sh
@@ -20,7 +20,10 @@ trap 'popd > /dev/null' EXIT
 
 
 ### CI-specific: Check K8s deployment status and configure CLI
-if [[ -n "${GITLAB_CI:-}" ]]; then
+if [[ -n "${CUSTOM_API_ENDPOINT:-}" ]]; then
+  VS_API="$CUSTOM_API_ENDPOINT"
+  echo "Using API endpoint from CUSTOM_API_ENDPOINT: https://$VS_API/api"
+elif [[ -n "${GITLAB_CI:-}" ]]; then
   echo "Running in GitLab CI - checking K8s deployment..."
   source ./configuration.sh
 

--- a/infra/blueprint/bringup/k8s_up.sh
+++ b/infra/blueprint/bringup/k8s_up.sh
@@ -26,8 +26,6 @@ source ./configuration.sh
 
 ./secrets.sh
 
-kubectl apply -f visual-search/templates/secret-access-rbac.yaml
-
 helm upgrade --install cosmos-embed ./triton-cosmos-embed \
   --values cosmos-embed-override.yaml \
   --timeout 45m

--- a/infra/blueprint/bringup/values-openshift.yaml
+++ b/infra/blueprint/bringup/values-openshift.yaml
@@ -1,0 +1,127 @@
+# values-openshift.yaml — OpenShift overlay for Cosmos Dataset Search.
+#
+# Usage:
+#   helm upgrade --install <release-name> infra/blueprint/bringup \
+#     --namespace <your-project> \
+#     -f infra/blueprint/bringup/values-openshift.yaml \
+#     --set "visual-search.openshift.secrets.ngcApiKey=$NGC_API_KEY" \
+#     --timeout 45m
+#
+# This file enables OpenShift-specific resources (Route, SCC, nginx proxy,
+# credential Secrets) and switches from subchart Deployments to NIM Operator
+# managed services.  Cluster-specific values (tolerations, storageClass, NGC
+# keys) should be passed via --set at install time.
+
+# ---------------------------------------------------------------------------
+# OpenShift features
+# ---------------------------------------------------------------------------
+visual-search:
+  openshift:
+    enabled: true
+    route:
+      enabled: true
+    scc:
+      create: true
+    secrets:
+      create: true
+    minio:
+      route:
+        enabled: true
+    nginx:
+      enabled: true
+
+  # ---------------------------------------------------------------------------
+  # NIM Operator integration — deploys cosmos-embed via NIMCache + NIMService.
+  # The NIM Operator handles model downloading, caching, and GPU scheduling.
+  # Requires: NIM Operator installed, NGC image-pull and API secrets in namespace.
+  # ---------------------------------------------------------------------------
+  nimOperator:
+    cosmosEmbed:
+      enabled: true
+      replicas: 1
+      service:
+        name: "cosmos-embed-nim"
+      image:
+        repository: nvcr.io/nim/nvidia/cosmos-embed1
+        tag: "1.0.0"
+        pullPolicy: Always
+      resources:
+        limits:
+          nvidia.com/gpu: 1
+        requests:
+          nvidia.com/gpu: 1
+      storage:
+        pvc:
+          create: true
+          size: "50Gi"
+          volumeAccessMode: ReadWriteOnce
+          storageClass: ""
+      secrets:
+        pullSecret: "ngc-secret"
+        authSecret: "ngc-api"
+      nodeSelector: {}
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        # Add cluster-specific tolerations as needed:
+        # - key: <your-gpu-taint-key>
+        #   operator: Equal
+        #   value: "true"
+        #   effect: NoSchedule
+      env:
+        - name: NIM_HTTP_API_PORT
+          value: "8000"
+      expose:
+        service:
+          name: http
+          type: ClusterIP
+          port: 8000
+      startupProbe:
+        enabled: true
+        probe:
+          httpGet:
+            path: /v1/health/ready
+            port: 8000
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          failureThreshold: 120
+
+visual-search-react-ui:
+  openshift:
+    enabled: true
+    nginx: true
+
+# ---------------------------------------------------------------------------
+# Disable cosmos-embed subchart Deployment — NIM Operator manages the lifecycle.
+# ---------------------------------------------------------------------------
+cosmos-embed:
+  enabled: false
+
+# ---------------------------------------------------------------------------
+# Milvus — enable built-in MinIO storage.
+# ---------------------------------------------------------------------------
+milvus:
+  minio:
+    enabled: true
+    mode: standalone
+  externalS3:
+    enabled: false
+  serviceAccount:
+    create: true
+    name: "s3-access-sa"
+  indexNode:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"
+    # Tolerations for GPU-tainted nodes (uncomment and adjust for your cluster).
+    # tolerations:
+    #   - key: "nvidia.com/gpu"
+    #     operator: Exists
+    #     effect: NoSchedule
+  etcd:
+    serviceAccount:
+      create: true
+  kafka:
+    zookeeper:
+      serviceAccount:
+        create: true

--- a/infra/blueprint/bringup/values.yaml
+++ b/infra/blueprint/bringup/values.yaml
@@ -28,12 +28,6 @@ global:
     keys:
       dbHost: "dep"
 
-milvus:
-  name: "milvus"
-  namespace: "default"
-  db: "default"
-  port: 19530
-
 storageSpec:
   name: "storage"
   port: 8080
@@ -86,3 +80,280 @@ visualSearchReactUi:
     tag: "1.0.0"
   port: 8080
   containerPort: 8080
+
+# ==========================================
+# Subchart defaults (umbrella chart only)
+# ==========================================
+
+# cosmos-embed subchart — enabled by default (standalone Deployment).
+# Set to false when using the NIM Operator instead.
+# When using k8s_up.sh, cosmos-embed is installed separately
+# with cosmos-embed-override.yaml. These defaults apply to umbrella deploys.
+cosmos-embed:
+  enabled: true
+  resources:
+    limits:
+      nvidia.com/gpu: 1
+      memory: "16Gi"
+      cpu: "2"
+    requests:
+      nvidia.com/gpu: 1
+      memory: "8Gi"
+      cpu: "1"
+  nim:
+    ngcAPISecret: ngc-api
+  persistence:
+    enabled: true
+    size: 50Gi
+  service:
+    name: cosmos-embed
+  envVars:
+    USE_CUDA_IPC: "1"
+    ENABLE_CUDA_MPS: "1"
+  extraVolumes:
+    tmp-ram:
+      emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+  extraVolumeMounts:
+    tmp-ram:
+      mountPath: /tmp/ram
+  startupProbe:
+    enabled: true
+    path: /v1/health/ready
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    failureThreshold: 180
+  readinessProbe:
+    enabled: true
+    path: /v1/health/ready
+    initialDelaySeconds: 30
+    periodSeconds: 10
+  livenessProbe:
+    enabled: true
+    path: /v1/health/live
+    initialDelaySeconds: 60
+    periodSeconds: 30
+
+# milvus subchart values.
+# Note: milvus.name/namespace/db/port are consumed by the visual-search
+# subchart templates (not the milvus subchart).
+milvus:
+  name: "milvus"
+  namespace: "default"
+  db: "default"
+  port: 19530
+  image:
+    all:
+      repository: "milvusdb/milvus"
+      tag: "v2.4.4"
+  minio:
+    enabled: false
+  externalS3:
+    enabled: true
+    host: "s3.${AWS_REGION}.amazonaws.com"
+    port: "443"
+    bucketName: "${S3_BUCKET_NAME}"
+    useSSL: true
+    useIAM: true
+    cloudProvider: "aws"
+    accessKey: ""
+    secretKey: ""
+    region: "${AWS_REGION}"
+  serviceAccount:
+    create: false
+    name: "s3-access-sa"
+  pulsar:
+    enabled: false
+  pulsarv3:
+    enabled: false
+  rootCoordinator:
+    replicas: 1
+    activeStandby:
+      enabled: true
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+  indexCoordinator:
+    replicas: 1
+    activeStandby:
+      enabled: true
+    resources:
+      requests:
+        cpu: "0.25"
+        memory: 256Mi
+      limits:
+        cpu: "0.5"
+        memory: 0.5Gi
+  queryCoordinator:
+    replicas: 1
+    activeStandby:
+      enabled: true
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: 1Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  dataCoordinator:
+    replicas: 1
+    activeStandby:
+      enabled: true
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: 4Gi
+      limits:
+        cpu: "1"
+        memory: 8Gi
+  proxy:
+    replicas: 1
+    resources:
+      requests:
+        cpu: "0.5"
+        memory: 2Gi
+      limits:
+        cpu: "1"
+        memory: 4Gi
+  queryNode:
+    replicas: 1
+    resources:
+      requests:
+        cpu: "12"
+        memory: 96Gi
+        ephemeral-storage: "100Gi"
+      limits:
+        cpu: "15"
+        memory: 120Gi
+        ephemeral-storage: "150Gi"
+    extraEnv:
+      - name: GOGC
+        value: "14"
+      - name: GOMEMLIMIT
+        value: "110GiB"
+      - name: KNOWHERE_ENABLE_GPU
+        value: "false"
+  dataNode:
+    resources:
+      requests:
+        cpu: 6
+        memory: 24Gi
+        ephemeral-storage: "40Gi"
+      limits:
+        cpu: 8
+        memory: 31Gi
+        ephemeral-storage: "40Gi"
+    extraEnv:
+      - name: GOGC
+        value: "50"
+      - name: GOMEMLIMIT
+        value: "24GiB"
+      - name: MEM_LIMIT
+        value: "24Gi"
+  indexNode:
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+        memory: "12Gi"
+        cpu: "3500m"
+        ephemeral-storage: "40Gi"
+      requests:
+        nvidia.com/gpu: 1
+        memory: "12Gi"
+        cpu: "3500m"
+        ephemeral-storage: "40Gi"
+    extraEnv:
+      - name: GOGC
+        value: "50"
+      - name: GOMEMLIMIT
+        value: "12GiB"
+      - name: MEM_LIMIT
+        value: "12Gi"
+      - name: KNOWHERE_ENABLE_GPU
+        value: "true"
+  extraConfigFiles:
+    user.yaml: |+
+      dataCoord:
+        import:
+          taskRetention: 1800
+      queryCoord:
+        memoryUsageMaxDifferencePercentage: 10
+      queryNode:
+        enableDisk: true
+        adapt_for_cpu: true
+        mmap:
+          vectorField: true
+          vectorIndex: true
+          scalarField: true
+          scalarIndex: true
+          growingMmapEnabled: true
+      indexNode:
+        scheduler:
+          buildParallel: 8
+      segment:
+        maxSize: 4Gi
+  etcd:
+    replicaCount: 1
+    autoCompactionMode: revision
+    autoCompactionRetention: "1"
+    extraEnvVars:
+      - name: ETCD_QUOTA_BACKEND_BYTES
+        value: "8589934592"
+      - name: ETCD_HEARTBEAT_INTERVAL
+        value: "500"
+      - name: ETCD_ELECTION_TIMEOUT
+        value: "25000"
+      - name: ETCD_SNAPSHOT_COUNT
+        value: "10000"
+    persistence:
+      enabled: true
+      size: 30Gi
+    resources:
+      requests:
+        cpu: 2
+        memory: 4Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
+  kafka:
+    enabled: true
+    replicaCount: 3
+    image:
+      registry: public.ecr.aws
+      repository: bitnami/kafka
+      tag: 3.7.1
+    defaultReplicationFactor: 1
+    offsetsTopicReplicationFactor: 1
+    heapOpts: "-Xmx8192M -Xms8192M"
+    zookeeper:
+      enabled: true
+      replicaCount: 1
+      heapSize: 2048
+      image:
+        registry: public.ecr.aws
+        repository: bitnami/zookeeper
+        tag: 3.8.4
+      persistence:
+        enabled: true
+        size: 20Gi
+      resources:
+        requests:
+          cpu: 1
+          memory: 2Gi
+        limits:
+          cpu: 2
+          memory: 4Gi
+    resources:
+      limits:
+        cpu: 2
+        memory: 12Gi
+        ephemeral-storage: "40Gi"
+      requests:
+        cpu: 2
+        memory: 12Gi
+        ephemeral-storage: "40Gi"

--- a/infra/blueprint/bringup/verify_and_configure_cors.sh
+++ b/infra/blueprint/bringup/verify_and_configure_cors.sh
@@ -11,6 +11,7 @@
 
 ## CORS Verification and Configuration Script for CDS S3 Buckets
 ## Usage: ./verify_and_configure_cors.sh [-y|--apply]
+## Set CUSTOM_API_ENDPOINT env var to skip EKS auto-detection (e.g. OpenShift Route)
 
 set -e
 
@@ -24,18 +25,25 @@ if [[ "$1" == "-y" || "$1" == "--apply" ]]; then
     APPLY_CORS=true
 fi
 
-source ./configuration.sh
+# Source EKS configuration only when CUSTOM_API_ENDPOINT is not provided
+if [ -z "${CUSTOM_API_ENDPOINT:-}" ]; then
+    source ./configuration.sh
+fi
 
 echo "=============================================="
 echo "  S3 CORS Verification"
 echo "=============================================="
 
-# Get ingress hostname and determine CORS origin
-INGRESS_HOSTNAME=$(kubectl get ingress simple-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || echo "")
+# Get hostname: use CUSTOM_API_ENDPOINT if set, otherwise auto-detect from ingress
+if [ -n "${CUSTOM_API_ENDPOINT:-}" ]; then
+    VS_API="$CUSTOM_API_ENDPOINT"
+else
+    VS_API=$(kubectl get ingress simple-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || echo "")
+fi
 
 # Determine CORS origin based on ingress availability
-if [ -n "$INGRESS_HOSTNAME" ]; then
-    CORS_ORIGIN="https://$INGRESS_HOSTNAME"
+if [ -n "$VS_API" ]; then
+    CORS_ORIGIN="https://$VS_API"
     CORS_MODE="secure (ingress hostname)"
 else
     CORS_ORIGIN="*"
@@ -93,12 +101,15 @@ check_bucket() {
     fi
 }
 
-# Check main bucket
-check_bucket "$S3_BUCKET_NAME" "$AWS_REGION" "" "Main Bucket"
-MAIN_STATUS=$?
+# Check main bucket (only when S3_BUCKET_NAME is set, e.g. EKS)
+MAIN_STATUS=0
+if [ -n "${S3_BUCKET_NAME:-}" ]; then
+    check_bucket "$S3_BUCKET_NAME" "$AWS_REGION" "" "Main Bucket"
+    MAIN_STATUS=$?
+fi
 
-# Check custom bucket if different
-if [ "$CUSTOM_S3_BUCKET_NAME" != "$S3_BUCKET_NAME" ]; then
+# Check custom bucket if set and different from main
+if [ -n "${CUSTOM_S3_BUCKET_NAME:-}" ] && [ "${CUSTOM_S3_BUCKET_NAME:-}" != "${S3_BUCKET_NAME:-}" ]; then
     # Set up AWS profile for custom bucket
     PROFILE_NAME="${CUSTOM_S3_BUCKET_NAME}-profile"
     aws configure set aws_access_key_id "$CUSTOM_AWS_ACCESS_KEY_ID" --profile "$PROFILE_NAME" 2>/dev/null
@@ -111,13 +122,12 @@ fi
 
 echo ""
 echo "=============================================="
-if [ -n "$INGRESS_HOSTNAME" ]; then
-    echo "Ingress: https://$INGRESS_HOSTNAME"
-    echo "CORS origin: $CORS_ORIGIN ($CORS_MODE)"
+if [ -n "$VS_API" ]; then
+    echo "Endpoint: https://$VS_API"
 else
-    echo "Ingress: Not available"
-    echo "CORS origin: $CORS_ORIGIN ($CORS_MODE)"
+    echo "Endpoint: Not available"
 fi
+echo "CORS origin: $CORS_ORIGIN ($CORS_MODE)"
 
 if [ "$APPLY_CORS" = true ]; then
     echo "Mode: Auto-apply"

--- a/infra/blueprint/bringup/visual-search-react-ui/templates/deployment.yaml
+++ b/infra/blueprint/bringup/visual-search-react-ui/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         app: {{ .Values.visualSearchReactUi.name }}
     spec:
+      {{- if .Values.openshift.enabled }}
+      serviceAccountName: cosmos-cds-sa
+      securityContext: {}
+      {{- end }}
       containers:
       - name: {{ .Values.visualSearchReactUi.name }}
         image: {{ .Values.visualSearchReactUi.image.repository }}:{{ .Values.visualSearchReactUi.image.tag }}
@@ -33,11 +37,23 @@ spec:
           - containerPort: {{ .Values.visualSearchReactUi.containerPort }}
         env:
         - name: CDS_API_URL
+          {{- if and .Values.openshift.enabled .Values.openshift.nginx }}
+          value: /api/v1
+          {{- else if and .Values.openshift.enabled .Values.openshift.route.enabled .Values.openshift.route.host }}
+          value: https://{{ .Values.openshift.route.host }}/api/v1
+          {{- else }}
           value: https://{{ .Values.global.ingress.host }}/api/v1
+          {{- end }}
         - name: CDS_CDN_URL
           value: "" # Set CDN URL if CDN is enabled - for now, CDN is not enabled - this will concatenate with asset IDs
         - name: CDS_UI_URL
+          {{- if and .Values.openshift.enabled .Values.openshift.nginx }}
+          value: /cosmos-dataset-search
+          {{- else if and .Values.openshift.enabled .Values.openshift.route.enabled .Values.openshift.route.host }}
+          value: https://{{ .Values.openshift.route.host }}/cosmos-dataset-search
+          {{- else }}
           value: https://{{ .Values.global.ingress.host }}/cosmos-dataset-search
+          {{- end }}
         - name: PORT
           value: '{{ .Values.visualSearchReactUi.containerPort }}'
         livenessProbe:

--- a/infra/blueprint/bringup/visual-search-react-ui/templates/ingress.yaml
+++ b/infra/blueprint/bringup/visual-search-react-ui/templates/ingress.yaml
@@ -8,7 +8,7 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
-{{- if .Values.global.ingress.enabled -}}
+{{- if and .Values.global.ingress.enabled (not (and .Values.openshift.enabled .Values.openshift.route.enabled)) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/infra/blueprint/bringup/visual-search-react-ui/templates/openshift.yaml
+++ b/infra/blueprint/bringup/visual-search-react-ui/templates/openshift.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.openshift.enabled .Values.openshift.route.enabled (not .Values.openshift.nginx) }}
+{{/* Route only created when nginx proxy is NOT in use (standalone mode).
+     When nginx is enabled, the visual-search chart creates a single Route
+     that handles both API and UI traffic. */}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Values.visualSearchReactUi.name }}
+  labels:
+    app: {{ .Values.visualSearchReactUi.name }}
+spec:
+  {{- if .Values.openshift.route.host }}
+  host: {{ .Values.openshift.route.host | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ .Values.visualSearchReactUi.name }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.visualSearchReactUi.containerPort }}
+  tls:
+    termination: {{ .Values.openshift.route.tls.termination }}
+    {{- if .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/infra/blueprint/bringup/visual-search-react-ui/values.yaml
+++ b/infra/blueprint/bringup/visual-search-react-ui/values.yaml
@@ -8,11 +8,35 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
+# Default values for visual-search-react-ui.
+
 replicaCount: 1
-image: "nvcr.io/nvidian/cosmos-vds-web-ui:latest"
-containerPort: 8080
+
+imagePullSecret: "nvcr-io"
+
+visualSearchReactUi:
+  name: "visual-search-react-ui"
+  image:
+    repository: "nvcr.io/nvidia/blueprint/cosmos-cds-ui"
+    tag: "1.0.0"
+  port: 8080
+  containerPort: 8080
+
 resources:
   requests:
-    cpu: "0.1"
+    reactUiCpu: "100m"
+
 ingress:
   prefix: visual-search-react-ui
+
+# OpenShift configuration (disabled by default).
+# Enabled via values-openshift.yaml overlay.
+openshift:
+  enabled: false
+  nginx: false
+  route:
+    enabled: false
+    host: ""
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect

--- a/infra/blueprint/bringup/visual-search/templates/_helpers.tpl
+++ b/infra/blueprint/bringup/visual-search/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Standard labels for all OpenShift resources.
+*/}}
+{{- define "visual-search.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{/*
+NGC image pull secret name.
+*/}}
+{{- define "visual-search.ngcPullSecret.name" -}}
+ngc-secret
+{{- end }}
+
+{{/*
+NGC image pull secret — reusable template for dockerconfigjson secrets.
+Usage: {{ include "visual-search.ngcPullSecret" (list $ "secret-name") }}
+*/}}
+{{- define "visual-search.ngcPullSecret" -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ index . 1 }}
+  namespace: {{ (index . 0).Release.Namespace }}
+  labels:
+    {{- include "visual-search.labels" (index . 0) | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: |
+    {
+      "auths": {
+        "nvcr.io": {
+          "username": "$oauthtoken",
+          "password": {{ (index . 0).Values.openshift.secrets.ngcApiKey | quote }}
+        }
+      }
+    }
+{{- end }}

--- a/infra/blueprint/bringup/visual-search/templates/deployment.yaml
+++ b/infra/blueprint/bringup/visual-search/templates/deployment.yaml
@@ -30,7 +30,11 @@ spec:
         - sh
         - -c
         - >-
+          {{- if .Values.openshift.enabled }}
+          until nc -z -v -w30 {{ .Release.Name }}-milvus.{{ .Release.Namespace }}.svc.cluster.local {{ .Values.milvus.port }};
+          {{- else }}
           until nc -z -v -w30 {{ .Values.milvus.name }}.{{ .Values.milvus.namespace }}.svc.cluster.local {{ .Values.milvus.port }};
+          {{- end }}
           do sleep 5; done
       containers:
       - name: {{ .Values.visualSearch.name }}
@@ -51,19 +55,36 @@ spec:
         - name: GUNICORN_WORKERS
           value: {{ .Values.env.GUNICORN_WORKERS | quote }}
         - name: MILVUS_DOCUMENT_STORE_URI
+          {{- if .Values.openshift.enabled }}
+          value: http://{{ .Release.Name }}-milvus.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.milvus.port }}
+          {{- else }}
           value: http://{{ .Values.milvus.name }}.{{ .Values.milvus.namespace }}.svc.cluster.local:{{ .Values.milvus.port }}
+          {{- end }}
         - name: MILVUS_DB
           value: {{ .Values.milvus.db | quote }}
         - name: FASTAPI_ROOT_PATH
           value: {{ .Values.env.FASTAPI_ROOT_PATH | quote }}
         - name: NVIDIA_API_KEY
+          {{- if .Values.openshift.enabled }}
+          valueFrom:
+            secretKeyRef:
+              name: ngc-api
+              key: NGC_API_KEY
+          {{- else }}
           value: {{ .Values.env.NVIDIA_API_KEY | quote }}
+          {{- end }}
         - name: SECRETS_ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:
               name: secret-encryption-key
               key: SECRETS_ENCRYPTION_KEY
         - name: COSMOS_EMBED_NIM_URI
+          {{- if .Values.nimOperator.cosmosEmbed.enabled }}
+          value: {{ .Values.nimOperator.cosmosEmbed.service.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.nimOperator.cosmosEmbed.expose.service.port }}
+          {{- else if .Values.openshift.enabled }}
+          value: {{ .Values.cosmosEmbed.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ index .Values.cosmosEmbed.ports 0 "port" }}
+          {{- else }}
           value: {{ .Values.cosmosEmbed.name }}.{{ .Values.global.namespace }}.svc.cluster.local:{{ index .Values.cosmosEmbed.ports 0 "port" }}
+          {{- end }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecret }}

--- a/infra/blueprint/bringup/visual-search/templates/nim-cosmos-embed.yaml
+++ b/infra/blueprint/bringup/visual-search/templates/nim-cosmos-embed.yaml
@@ -1,0 +1,66 @@
+{{- $nim := .Values.nimOperator.cosmosEmbed -}}
+{{- if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq $nim.enabled true) }}
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMCache
+metadata:
+  name: {{ $nim.service.name }}-cache
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  source:
+    ngc:
+      modelPuller: "{{ $nim.image.repository }}:{{ $nim.image.tag }}"
+      pullSecret: {{ $nim.secrets.pullSecret }}
+      authSecret: {{ $nim.secrets.authSecret }}
+  storage:
+    pvc:
+      create: {{ $nim.storage.pvc.create | default true }}
+      {{- if $nim.storage.pvc.storageClass }}
+      storageClass: {{ $nim.storage.pvc.storageClass }}
+      {{- end }}
+      size: {{ $nim.storage.pvc.size | default "50Gi" }}
+      volumeAccessMode: {{ $nim.storage.pvc.volumeAccessMode | default "ReadWriteOnce" }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: apps.nvidia.com/v1alpha1
+kind: NIMService
+metadata:
+  name: {{ $nim.service.name }}
+spec:
+  image:
+    repository: {{ $nim.image.repository }}
+    tag: "{{ $nim.image.tag }}"
+    pullPolicy: {{ $nim.image.pullPolicy | default "Always" }}
+    pullSecrets:
+      - {{ $nim.secrets.pullSecret }}
+  authSecret: {{ $nim.secrets.authSecret }}
+  storage:
+    nimCache:
+      name: {{ $nim.service.name }}-cache
+  replicas: {{ $nim.replicas | default 1 }}
+  resources:
+{{ toYaml $nim.resources | nindent 4 }}
+  expose:
+{{ toYaml $nim.expose | nindent 4 }}
+  env:
+{{ toYaml $nim.env | nindent 4 }}
+  {{- with $nim.startupProbe }}
+  {{- if .enabled }}
+  startupProbe:
+    enabled: true
+    probe:
+{{ toYaml .probe | nindent 6 }}
+  {{- end }}
+  {{- end }}
+  {{- with $nim.tolerations }}
+  tolerations:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $nim.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/infra/blueprint/bringup/visual-search/templates/openshift.yaml
+++ b/infra/blueprint/bringup/visual-search/templates/openshift.yaml
@@ -1,0 +1,387 @@
+{{- if .Values.openshift.enabled }}
+
+# Custom SCC: allows runAsUser for subchart pods (milvus-minio, kafka, etc.)
+# and skips recursive SELinux relabeling on NIM model PVCs.
+{{- if .Values.openshift.scc.create }}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.openshift.scc.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "visual-search.labels" . | nindent 4 }}
+
+---
+
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ .Release.Name }}-nim
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/description: >-
+      Custom SCC for CDS pods. Allows containers to run as the UID defined
+      in their images and skips recursive SELinux relabeling on volume mounts.
+priority: 20
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:default
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.openshift.scc.serviceAccountName }}
+  - system:serviceaccount:{{ .Release.Namespace }}:nim-cache-sa
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - system:serviceaccount:{{ $.Release.Namespace }}:{{ $nimVal.service.name }}
+  {{- end }}
+  {{- end }}
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-nim-scc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:{{ .Release.Name }}-nim
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: nim-cache-sa
+    namespace: {{ .Release.Namespace }}
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - kind: ServiceAccount
+    name: {{ $nimVal.service.name }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+  {{- end }}
+
+---
+
+# Anyuid SCC RoleBinding — grants the anyuid SCC to subchart service accounts
+# whose containers run as specific UIDs (etcd, kafka, minio, etc.).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-anyuid-scc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ .Values.openshift.scc.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: s3-access-sa
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-kafka
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-minio
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-etcd
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-zookeeper
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cosmos-embed
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: nim-cache-sa
+    namespace: {{ .Release.Namespace }}
+  {{- range $nimKey, $nimVal := .Values.nimOperator }}
+  {{- if and (kindIs "map" $nimVal) (hasKey $nimVal "service") }}
+  - kind: ServiceAccount
+    name: {{ $nimVal.service.name }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
+# Nginx reverse proxy — single entry point for API + UI
+{{- if .Values.openshift.nginx.enabled }}
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-proxy-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "visual-search.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    upstream api {
+      server {{ .Values.visualSearch.name }}:{{ .Values.visualSearch.port }};
+    }
+    upstream ui {
+      server {{ .Values.visualSearchReactUi.name | default "visual-search-react-ui" }}:8080;
+    }
+    server {
+      listen 8080;
+
+      location /api/ {
+        proxy_pass http://api/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 500m;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+      }
+
+      location / {
+        proxy_pass http://ui/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+      }
+
+      location /health {
+        return 200 'ok';
+        add_header Content-Type text/plain;
+      }
+    }
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-proxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: nginx-proxy
+    {{- include "visual-search.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-proxy
+  template:
+    metadata:
+      labels:
+        app: nginx-proxy
+    spec:
+      containers:
+      - name: nginx
+        image: {{ .Values.openshift.nginx.image.repository }}:{{ .Values.openshift.nginx.image.tag }}
+        imagePullPolicy: {{ .Values.openshift.nginx.image.pullPolicy }}
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          {{- toYaml .Values.openshift.nginx.resources | nindent 10 }}
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+        - name: cache
+          mountPath: /var/cache/nginx
+        - name: run
+          mountPath: /var/run
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-proxy-config
+      - name: tmp
+        emptyDir: {}
+      - name: cache
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-proxy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: nginx-proxy
+    {{- include "visual-search.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: nginx-proxy
+  ports:
+  - port: {{ .Values.openshift.nginx.service.port }}
+    targetPort: http
+    name: http
+
+{{- end }}
+
+# OpenShift Route
+{{- if .Values.openshift.route.enabled }}
+
+---
+
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Values.visualSearch.name }}
+  labels:
+    app: {{ .Values.visualSearch.name }}
+    {{- include "visual-search.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.openshift.route.host }}
+  host: {{ .Values.openshift.route.host | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    {{- if .Values.openshift.nginx.enabled }}
+    name: nginx-proxy
+    {{- else }}
+    name: {{ .Values.visualSearch.name }}
+    {{- end }}
+    weight: 100
+  port:
+    {{- if .Values.openshift.nginx.enabled }}
+    targetPort: http
+    {{- else }}
+    targetPort: {{ int .Values.env.GUNICORN_PORT }}
+    {{- end }}
+  tls:
+    termination: {{ .Values.openshift.route.tls.termination }}
+    {{- if .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+  wildcardPolicy: None
+{{- end }}
+
+# MinIO Route — exposes MinIO for browser access to video assets
+{{- if .Values.openshift.minio.route.enabled }}
+
+---
+
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Values.openshift.minio.route.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: minio
+    {{- include "visual-search.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.openshift.minio.route.host }}
+  host: {{ .Values.openshift.minio.route.host | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ .Values.openshift.minio.serviceName }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.openshift.minio.port }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+{{- end }}
+
+# Secrets (Helm-managed)
+{{- if .Values.openshift.secrets.create }}
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ngc-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "visual-search.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  NGC_API_KEY: {{ .Values.openshift.secrets.ngcApiKey | default "" | quote }}
+
+{{- if .Values.openshift.secrets.ngcApiKey }}
+---
+{{ include "visual-search.ngcPullSecret" (list . "ngc-secret") }}
+---
+{{ include "visual-search.ngcPullSecret" (list . "nvcr-io") }}
+{{- end }}
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-encryption-key
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "visual-search.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  SECRETS_ENCRYPTION_KEY: {{ .Values.openshift.secrets.secretsEncryptionKey | default (randAlphaNum 32) | quote }}
+{{- end }}
+
+{{- end }}

--- a/infra/blueprint/bringup/visual-search/templates/secret-access-rbac.yaml
+++ b/infra/blueprint/bringup/visual-search/templates/secret-access-rbac.yaml
@@ -8,16 +8,25 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
+# Grants access to secrets in "default" namespace.
+# On OpenShift, keyed by namespace for independent cleanup.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: default
+  {{- if .Values.openshift.enabled }}
+  name: {{ .Release.Namespace }}-secret-access-role
+  labels:
+    {{- include "visual-search.labels" . | nindent 4 }}
+  {{- else }}
   name: secret-access-role
   labels:
     app.kubernetes.io/managed-by: Helm
   annotations:
     meta.helm.sh/release-name: visual-search
     meta.helm.sh/release-namespace: default
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -28,18 +37,29 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: secret-access-binding
   namespace: default
+  {{- if .Values.openshift.enabled }}
+  name: {{ .Release.Namespace }}-secret-access-binding
+  labels:
+    {{- include "visual-search.labels" . | nindent 4 }}
+  {{- else }}
+  name: secret-access-binding
   labels:
     app.kubernetes.io/managed-by: Helm
   annotations:
     meta.helm.sh/release-name: visual-search
     meta.helm.sh/release-namespace: default
+  {{- end }}
 subjects:
 - kind: ServiceAccount
   name: s3-access-sa
-  namespace: default
+  namespace: {{ if .Values.openshift.enabled }}{{ .Release.Namespace }}{{ else }}default{{ end }}
+{{- if and .Values.openshift.enabled .Values.openshift.scc.create }}
+- kind: ServiceAccount
+  name: {{ .Values.openshift.scc.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 roleRef:
   kind: Role
-  name: secret-access-role
-  apiGroup: rbac.authorization.k8s.io 
+  name: {{ if .Values.openshift.enabled }}{{ .Release.Namespace }}-secret-access-role{{ else }}secret-access-role{{ end }}
+  apiGroup: rbac.authorization.k8s.io

--- a/infra/blueprint/bringup/visual-search/values.yaml
+++ b/infra/blueprint/bringup/visual-search/values.yaml
@@ -8,15 +8,136 @@
 # without an express license agreement from NVIDIA CORPORATION or
 # its affiliates is strictly prohibited.
 
+# Default values for visual-search.
+
 replicaCount: 1
-image: "nvcr.io/nvidian/visual-search:latest"
-containerPort: 8888
-resources:
-  requests:
-    cpu: 500m
+
+imagePullSecret: "nvcr-io"
+
+visualSearch:
+  name: "visual-search"
+  image:
+    repository: "nvcr.io/nvidia/blueprint/cosmos-dataset-search"
+    tag: "1.0.0"
+  port: 8888
+  containerPort: 8888
+
+visualSearchReactUi:
+  name: "visual-search-react-ui"
+
+milvus:
+  name: "milvus"
+  namespace: "default"
+  db: "default"
+  port: 19530
+
+cosmosEmbed:
+  name: "cosmos-embed"
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+
 env:
+  MAX_DOCS_PER_UPLOAD: "10000"
   GUNICORN_PORT: "8888"
+  GUNICORN_TIMEOUT: "300"
   GUNICORN_WORKERS: "1"
   FASTAPI_ROOT_PATH: "/api"
-  MAX_DOCS_PER_UPLOAD: "10000"
-  GUNICORN_TIMEOUT: "300"
+  NVIDIA_API_KEY: ""
+
+resources:
+  requests:
+    visualSearchCpu: "500m"
+
+# ---------------------------------------------------------------------------
+# OpenShift support (disabled by default — zero impact on vanilla Kubernetes)
+# ---------------------------------------------------------------------------
+openshift:
+  enabled: false
+  route:
+    enabled: false
+    host: ""
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+  scc:
+    create: false
+    serviceAccountName: "cosmos-cds-sa"
+  secrets:
+    create: false
+    ngcApiKey: ""
+    secretsEncryptionKey: ""
+  minio:
+    route:
+      enabled: false
+      name: "minio"
+      host: ""
+    serviceName: "cosmos-cds-minio"
+    port: 9000
+  nginx:
+    enabled: false
+    image:
+      repository: nginxinc/nginx-unprivileged
+      tag: "1.25.3-alpine"
+      pullPolicy: IfNotPresent
+    service:
+      port: 8080
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "50m"
+      limits:
+        memory: "128Mi"
+        cpu: "200m"
+
+# ---------------------------------------------------------------------------
+# NIM Operator integration (disabled by default).
+# When enabled AND the NIM Operator CRD is present on the cluster, NIMCache +
+# NIMService resources are created instead of the subchart Deployment.
+# Disable the cosmos-embed subchart (cosmos-embed.enabled: false) in your
+# overlay to avoid running both paths.
+# ---------------------------------------------------------------------------
+nimOperator:
+  cosmosEmbed:
+    enabled: false
+    replicas: 1
+    service:
+      name: "cosmos-embed-nim"
+    image:
+      repository: nvcr.io/nim/nvidia/cosmos-embed1
+      tag: "1.0.0"
+      pullPolicy: Always
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+      requests:
+        nvidia.com/gpu: 1
+    storage:
+      pvc:
+        create: true
+        size: "50Gi"
+        volumeAccessMode: ReadWriteOnce
+        storageClass: ""
+    secrets:
+      pullSecret: "ngc-secret"
+      authSecret: "ngc-api"
+    nodeSelector: {}
+    tolerations: []
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+    expose:
+      service:
+        name: http
+        type: ClusterIP
+        port: 8000
+    startupProbe:
+      enabled: true
+      probe:
+        httpGet:
+          path: /v1/health/ready
+          port: 8000
+        initialDelaySeconds: 60
+        periodSeconds: 30
+        failureThreshold: 120

--- a/infra/blueprint/ingest_custom_videos.sh
+++ b/infra/blueprint/ingest_custom_videos.sh
@@ -45,10 +45,15 @@ else
     aws configure set aws_access_key_id "${CUSTOM_AWS_ACCESS_KEY_ID}" --profile "${PROFILE_NAME}"
     aws configure set aws_secret_access_key "${CUSTOM_AWS_SECRET_ACCESS_KEY}" --profile "${PROFILE_NAME}"
     aws configure set region "${CUSTOM_AWS_REGION}" --profile "${PROFILE_NAME}"
+    if [[ -n "${CUSTOM_ENDPOINT_URL:-}" ]]; then
+        aws configure set endpoint_url "${CUSTOM_ENDPOINT_URL}" --profile "${PROFILE_NAME}"
+    fi
 fi
 
 # Determine execution context (CI vs local)
-if [[ -n "${GITLAB_CI:-}" ]]; then
+if [[ -n "${CUSTOM_API_ENDPOINT:-}" ]]; then
+  KUBECTL_CMD="${CUSTOM_KUBECTL_CMD:-oc}"
+elif [[ -n "${GITLAB_CI:-}" ]]; then
   echo "Running in GitLab CI environment..."
   KUBECTL_CMD="kubectl"
 else
@@ -57,23 +62,41 @@ else
 fi
 
 # Get ingress hostname
-VS_API=$($KUBECTL_CMD get ingress simple-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+if [[ -n "${CUSTOM_API_ENDPOINT:-}" ]]; then
+  VS_API="$CUSTOM_API_ENDPOINT"
+else
+  VS_API=$($KUBECTL_CMD get ingress simple-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+fi
 echo "Deployment URL: https://$VS_API/cosmos-dataset-search"
 
-# Create Kubernetes secret with AWS credentials
+# Create Kubernetes secret with AWS credentials.
+# The visual-search app reads secrets from the "default" namespace,
+# so when running on OpenShift (CUSTOM_API_ENDPOINT set) we target "default".
 SECRETS_NAME="${CUSTOM_S3_BUCKET_NAME}-secrets-videos"
+if [[ -n "${CUSTOM_API_ENDPOINT:-}" ]] && [[ -z "${CUSTOM_SECRET_NAMESPACE:-}" ]]; then
+  CUSTOM_SECRET_NAMESPACE="default"
+fi
+NS_FLAG=""
+if [[ -n "${CUSTOM_SECRET_NAMESPACE:-}" ]]; then
+  NS_FLAG="-n $CUSTOM_SECRET_NAMESPACE"
+fi
 
 # Check if secret already exists
-if $KUBECTL_CMD get secret $SECRETS_NAME &>/dev/null; then
+if $KUBECTL_CMD get secret $SECRETS_NAME $NS_FLAG &>/dev/null; then
     echo "Kubernetes secret '$SECRETS_NAME' already exists. Deleting and recreating..."
-    $KUBECTL_CMD delete secret $SECRETS_NAME
+    $KUBECTL_CMD delete secret $SECRETS_NAME $NS_FLAG
 fi
 
 echo "Creating Kubernetes secret with AWS credentials..."
-$KUBECTL_CMD create secret generic $SECRETS_NAME \
+ENDPOINT_FLAG=""
+if [[ -n "${CUSTOM_ENDPOINT_URL:-}" ]]; then
+    ENDPOINT_FLAG="--from-literal=endpoint_url=$CUSTOM_ENDPOINT_URL"
+fi
+$KUBECTL_CMD create secret generic $SECRETS_NAME $NS_FLAG \
   --from-literal=aws_access_key_id=$CUSTOM_AWS_ACCESS_KEY_ID \
   --from-literal=aws_secret_access_key=$CUSTOM_AWS_SECRET_ACCESS_KEY \
-  --from-literal=aws_region=$CUSTOM_AWS_REGION
+  --from-literal=aws_region=$CUSTOM_AWS_REGION \
+  $ENDPOINT_FLAG
 
 ### Now we need to create a collection for the data.
 ### The tag file tells the UI how to download images and videos.


### PR DESCRIPTION
## Description
This PR adds full OpenShift deployment support for the Cosmos Dataset Search Blueprint, validated end-to-end on an OpenShift cluster with the NIM Operator. The entire deployment is declarative via Helm with no external scripts required.

## What's Included

**Umbrella Helm Chart**
- `Chart.yaml` wires all dependencies (visual-search, visual-search-react-ui, cosmos-embed NIM, Milvus) into a single deployable chart.
- An `openshift.enabled` flag in the base chart values (off by default, zero impact on non-OpenShift deployments)

**OpenShift Templates**
- `visual-search/templates/openshift.yaml` - conditional template that creates OpenShift Routes (edge TLS via nginx reverse proxy), a custom SecurityContextConstraints (prevents SELinux relabeling on large NIM model volumes), and SCC RoleBindings for all required service accounts. It also provisions NGC image pull secrets, API key and encryption key secrets, and a namespace-scoped RoleBinding for secure secret access.
- `visual-search/templates/nim-cosmos-embed.yaml` - NIM Operator template creating NIMCache + NIMService pairs for the Cosmos-embed model, gated by `.Capabilities.APIVersions.Has` so it renders only when the NIM Operator is installed.
- `visual-search-react-ui/templates/openshift.yaml` - standalone OpenShift Route for the React UI (used when nginx proxy is not enabled).

**Deployment Updates**
- `visual-search/templates/deployment.yaml` and `visual-search-react-ui/templates/deployment.yaml`  - deployment templates updated for OpenShift-aware service discovery, security context, and dynamic routing.
- `visual-search/templates/secret-access-rbac.yaml` - namespace-scoped RBAC names for OpenShift to allow independent cleanup across projects
- `_helpers.tpl` introduces reusable Helm helpers for consistent labeling and NGC pull secret generation.

**Configuration**
- `values-openshift.yaml` - overlay file enabling OpenShift features, NIM Operator for cosmos-embed, MinIO-backed Milvus storage, and GPU node tolerations
- `values.yaml` - extends base configuration with subchart defaults for cosmos-embed and full Milvus configuration (coordinators, nodes, etcd, Kafka).
- `visual-search/values.yaml` and `visual-search-react-ui/values.yaml` - add `openshift` and `nimOperator` configuration blocks (disabled by default).

**Script Compatibility**
- `client_up.sh`, `verify_and_configure_cors.sh`, `ingest_custom_videos.sh`, and `k8s_up.sh` updated for OpenShift compatibility with environment-driven endpoints and
  MinIO support.
- `.gitignore` adds Helm-generated `charts/` directory.

**Documentation**
- `docs/docs/openshift-deployment.md` -  full deployment runbook covering prerequisites, NIM Operator setup, step-by-step deployment, verification, CDS CLI installation, data ingestion (MinIO and AWS S3), troubleshooting, and cleanup.
- `README.md` adds OpenShift deployment guide link to the Helm deployment section.

### How it works
Users deploy with a single command - secrets, Routes, SCC grants, and NIM Operator resources are all handled by the chart:
```bash
helm dependency build infra/blueprint/bringup

helm upgrade --install <release-name> infra/blueprint/bringup \
  -n <namespace> \
  -f infra/blueprint/bringup/values-openshift.yaml \
  --set "visual-search.openshift.secrets.ngcApiKey=$NGC_API_KEY" \
  --timeout 45m
