### PR TITLE
Fix unsafe classifier deserialization (CWE-502)

### DIFF
--- a/src/haystack/components/filtering_models.py
+++ b/src/haystack/components/filtering_models.py
@@ -10,8 +10,6 @@
 
 """Haystack components for document filtering models."""
 
-import base64
-import pickle
 from typing import Any, Dict, List
 
 import numpy as np
@@ -20,11 +18,38 @@ from haystack import Document, component
 from src.haystack.serializer import SerializerMixin
 
 
+def _linear_classifier_predictions(
+    embeddings: np.ndarray, clf: Dict[str, Any]
+) -> np.ndarray:
+    weights = clf.get("weights", clf)
+    try:
+        coef = np.asarray(weights["coef"], dtype=np.float32)
+        intercept = np.asarray(weights["intercept"], dtype=np.float32)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "clf must contain linear classifier weights with coef and intercept"
+        ) from exc
+
+    if coef.ndim != 2 or intercept.ndim != 1:
+        raise ValueError("clf weights must contain 2D coef and 1D intercept")
+    if coef.shape[0] != 1 or intercept.shape[0] != 1:
+        raise ValueError("clf weights must describe a binary linear classifier")
+    if embeddings.shape[1] != coef.shape[1]:
+        raise ValueError(
+            "clf coef dimension "
+            f"{coef.shape[1]} does not match embedding dimension "
+            f"{embeddings.shape[1]}"
+        )
+
+    scores = embeddings @ coef.T + intercept
+    return scores[:, 0] > 0
+
+
 @component
 class LinearClassifierFilter(SerializerMixin):
     """Class definition for a linear classifier which is used to filter results based on the classification score.
 
-    The classifier object is passed as base64 encoded string.
+    The classifier weights are passed as coefficients and intercept terms.
     """
 
     @component.output_types(documents=List[Document])
@@ -42,10 +67,8 @@ class LinearClassifierFilter(SerializerMixin):
         if documents[0].embedding is None:
             raise TypeError("To enable filtering, please set reconstuct=True")
 
-        best_model = pickle.loads(base64.b64decode(clf["model"])).get_best_model()
-
         all_embeddings = np.array([doc.embedding for doc in documents])
-        preds = best_model.predict(all_embeddings)
+        preds = _linear_classifier_predictions(all_embeddings, clf)
 
         filtered_documents = []
         for doc, pred in zip(documents, preds):

--- a/src/haystack/components/tests/filtering_models_test.py
+++ b/src/haystack/components/tests/filtering_models_test.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+"""Unit tests for Haystack filtering models."""
+
+import pytest
+from haystack import Document
+
+from src.haystack.components.filtering_models import LinearClassifierFilter
+
+
+def test_linear_classifier_filter_uses_weights() -> None:
+    docs = [
+        Document(content="drop", embedding=[-1.0, 0.0]),
+        Document(content="keep", embedding=[1.0, 0.0]),
+    ]
+    clf = {
+        "weights": {"coef": [[1.0, 0.0]], "intercept": [0.0]},
+        "model": "legacy-model-field-is-ignored",
+    }
+
+    result = LinearClassifierFilter().run(docs, clf=clf)
+
+    assert [doc.content for doc in result["documents"]] == ["keep"]
+    assert result["documents"][0].embedding is None
+
+
+def test_linear_classifier_filter_rejects_model_only_payload() -> None:
+    docs = [
+        Document(content="doc", embedding=[1.0, 0.0]),
+    ]
+
+    with pytest.raises(ValueError, match="weights"):
+        LinearClassifierFilter().run(
+            docs, clf={"model": "legacy-model-field-is-not-deserialized"}
+        )

--- a/src/visual_search/common/models.py
+++ b/src/visual_search/common/models.py
@@ -1045,7 +1045,8 @@ class LinearClassifierBase(BaseModel):
 class LinearClassifierResponse(BaseModel):
     weights: LinearClassifierBase = Field(description="Coefficients and intercept")
     model: str = Field(
-        description="Pickled LinearClassifier model b64 bytes as a utf-8 string to be parsed"
+        default="",
+        description="Deprecated. Classifier filtering uses weights instead of serialized models."
     )
 
 

--- a/src/visual_search/tests/test_search_refinement.py
+++ b/src/visual_search/tests/test_search_refinement.py
@@ -124,5 +124,5 @@ async def test_train_linear_classifier_happy_path(monkeypatch):
 
     resp = await sr.train(req)
     assert hasattr(resp, "weights") and resp.weights.coef == [[0.11, 0.22]] and resp.weights.intercept == [0.33]
-    assert isinstance(resp.model, str) and len(resp.model) > 0
+    assert resp.model == ""  # model field is deprecated; filtering now uses weights
 

--- a/src/visual_search/v1/apis/search_refinement.py
+++ b/src/visual_search/v1/apis/search_refinement.py
@@ -11,9 +11,7 @@
 """Endpoint to train a collection of search refinement models."""
 
 
-import base64
-import pickle
-from typing import Final, List, Tuple, Union
+from typing import List, Tuple, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException
 
@@ -32,13 +30,7 @@ from ...common.models import (
 from ...common.pipelines import get_document_stores, run_linear_probe_pipeline
 from ...logger import logger
 from .document_indexing import create_safe_name
-
-PICKLE_PROTOCOL: Final[int] = 5
 router = APIRouter()
-
-
-def _serialize_model(model, protocol: int = PICKLE_PROTOCOL) -> str:
-    return base64.b64encode(pickle.dumps(model, protocol=protocol)).decode("utf-8")
 
 
 @router.post(
@@ -196,14 +188,11 @@ async def train(
         )
 
     elif search_refinement_request.model_type == SearchRefinementMode.LINEAR_CLASSIFIER:
-        clf, weights = run_linear_classifier_training(
+        _, weights = run_linear_classifier_training(
             labelled_embeddings=labelled_embeddings
         )
 
-        response = LinearClassifierResponse(
-            weights=weights,
-            model=_serialize_model(clf),
-        )
+        response = LinearClassifierResponse(weights=weights)
 
     else:
         raise HTTPException(


### PR DESCRIPTION
## Summary
Fixes an unsafe deserialization vulnerability (CWE-502) in the linear-classifier search-refinement path.

The `LinearClassifierFilter` previously reconstructed the classifier by unpickling a client-supplied, base64-encoded blob:

```python
best_model = pickle.loads(base64.b64decode(clf["model"])).get_best_model()
```

Because `clf["model"]` originates from request input, a crafted pickle payload could execute arbitrary code during deserialization on the service.

## Fix
- Remove all `pickle`/`base64` deserialization from the classifier filter.
- Replace it with a safe, purely numeric linear prediction computed directly from the trained classifier weights (`coef` / `intercept`), with explicit shape and embedding-dimension validation.
- `search_refinement/train` no longer serializes a pickled model; the now-unused `model` field on `LinearClassifierResponse` is deprecated and defaults to empty.

## Files
- `src/haystack/components/filtering_models.py` — safe weights-based prediction (`_linear_classifier_predictions`), pickle removed.
- `src/visual_search/v1/apis/search_refinement.py` — stop serializing pickled models.
- `src/visual_search/common/models.py` — deprecate `model` field (default empty).
- `src/haystack/components/tests/filtering_models_test.py` (new) + `src/visual_search/tests/test_search_refinement.py` — coverage for the safe path.

## Notes
- No image references or deployment configuration are changed in this PR; it is scoped strictly to the security fix.

## Test plan
- [x] `pytest src/haystack/components/tests/filtering_models_test.py`
- [x] `pytest src/visual_search/tests/test_search_refinement.py`
- [x] Train a linear-classifier refinement model and confirm filtering works end-to-end without serialized models.
